### PR TITLE
Playback Diagnostics initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+.classpath
+.project

--- a/src/main/java/com/netflix/common/EventSubscriber.java
+++ b/src/main/java/com/netflix/common/EventSubscriber.java
@@ -1,0 +1,18 @@
+package com.netflix.common;
+
+/**
+ * Interface which must be implemented by all event subscribers
+ * which are to received event notifications. 
+ * @author tom
+ *
+ * @param <T> the type of the event the wrapping {@link SynchronizedEventBus}
+ *            will pass to the subscriber.
+ */
+public interface EventSubscriber<T> {
+  /**
+   * Notifies the underlying implementation that the given
+   * event occurred.
+   * @param event the event
+   */
+  public void onEvent(T event);
+}

--- a/src/main/java/com/netflix/common/SynchronizedEventBus.java
+++ b/src/main/java/com/netflix/common/SynchronizedEventBus.java
@@ -15,23 +15,6 @@ import java.util.Set;
  */
 public class SynchronizedEventBus<T> {
   
-  /**
-   * Interface which must be implemented by all event subscribers
-   * which are to received event notifications. 
-   * @author tom
-   *
-   * @param <T> the type of the event the wrapping {@link SynchronizedEventBus}
-   *            will pass to the subscriber.
-   */
-  public interface EventSubscriber<T> {
-    /**
-     * Notifies the underlying implementation that the given
-     * event occurred.
-     * @param event the event
-     */
-    public void onEvent(T event);
-  }
-  
   private final Set<EventSubscriber<T>> subscribers = Collections.synchronizedSet(new HashSet<EventSubscriber<T>>());
   
   /**

--- a/src/main/java/com/netflix/common/SynchronizedEventBus.java
+++ b/src/main/java/com/netflix/common/SynchronizedEventBus.java
@@ -15,7 +15,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  *
  * @param <T> the type of the events this bus will accept and propagate to subscribers
  */
-public class SynchronizedEventBus<T> {
+public final class SynchronizedEventBus<T> {
   
   // Use a CopyOnWriteArraySet to store the subscribers. This ensures we don't need to
   // synchronize access (optimizing for postEvent speed). Mutation is more expensive

--- a/src/main/java/com/netflix/common/SynchronizedEventBus.java
+++ b/src/main/java/com/netflix/common/SynchronizedEventBus.java
@@ -1,0 +1,63 @@
+package com.netflix.common;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A synchronized (thread-safe) event bus.
+ * 
+ * Allows subscribers to be registered and then notified whenever a new event is
+ * posted to the bus. 
+ * @author tom
+ *
+ * @param <T> the type of the events this bus will accept and propagate to subscribers
+ */
+public class SynchronizedEventBus<T> {
+  
+  /**
+   * Interface which must be implemented by all event subscribers
+   * which are to received event notifications. 
+   * @author tom
+   *
+   * @param <T> the type of the event the wrapping {@link SynchronizedEventBus}
+   *            will pass to the subscriber.
+   */
+  public interface EventSubscriber<T> {
+    /**
+     * Notifies the underlying implementation that the given
+     * event occurred.
+     * @param event the event
+     */
+    public void onEvent(T event);
+  }
+  
+  private final Set<EventSubscriber<T>> subscribers = Collections.synchronizedSet(new HashSet<EventSubscriber<T>>());
+  
+  /**
+   * Registers an {@link EventSubscriber} instance to receive notifications from
+   * this {@link SynchronizedEventBus}. 
+   * 
+   * Note that registering the same subscriber instance more than once has no
+   * effect.
+   * 
+   * @param subscriber the subscriber instance
+   */
+  public void addSubscriber(EventSubscriber<T> subscriber) {
+    this.subscribers.add(subscriber);
+  }
+  
+  /**
+   * Posts a new event to the event bus which in turn will propagate
+   * it to all registered subscribers.
+   * @param event the event
+   */
+  public void postEvent(T event) {
+    // Ensure we synchronize on the Set as we are iterating.
+    synchronized (subscribers) {
+      for (EventSubscriber<T> subscriber : subscribers) {
+        subscriber.onEvent(event);
+      }      
+    }
+  }
+}

--- a/src/main/java/com/netflix/playback/features/model/DiagnosticService.java
+++ b/src/main/java/com/netflix/playback/features/model/DiagnosticService.java
@@ -5,7 +5,7 @@ public abstract class DiagnosticService {
     protected Timer timer;
     protected int numCompletedPeriods;
     
-    public DiagnosticService(Timer timer, int numCompletedPeriods) {
+    public DiagnosticService(Timer timer) {
         this.timer = timer;
     }
     

--- a/src/main/java/com/netflix/playback/features/model/KeyCounter.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyCounter.java
@@ -1,0 +1,78 @@
+package com.netflix.playback.features.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A counter which maintains separate per-key counts.
+ * 
+ * Reads and writes are synchronized
+ * 
+ * @author tom
+ *
+ */
+public class KeyCounter {
+
+  private final Map<String, AtomicInteger> countMap = new HashMap<String, AtomicInteger>();
+  
+  /**
+   * Creates a counter for the given key if it does not already exists and 
+   * returns it. Returns the existing counter if it already exists.
+   * @param key the key identifying the counter
+   * @return the counter associated with the key
+   */
+  private synchronized AtomicInteger ensureCounter(String key) {
+    AtomicInteger counter;
+    if (this.countMap.containsKey(key)) {
+      counter = countMap.get(key);
+    } else {
+      counter = new AtomicInteger();
+      countMap.put(key, counter);
+    }
+    return counter;
+  }
+  
+  /**
+   * Increments the count for the given key by 1.
+   * @param key the key
+   */
+  public void increment(String key) {
+    this.ensureCounter(key).incrementAndGet();
+  }
+  
+  /**
+   * Increments the count for the given key by the given value.
+   * @param key the key
+   * @param value the value to increment by
+   */
+  public void increment(String key, int value) {
+    this.ensureCounter(key).addAndGet(value);
+  }
+  
+  /**
+   * Returns the current count for the given key.
+   * @param key the key
+   * @return the count
+   */
+  public synchronized int getCount(String key) {
+    if (this.countMap.containsKey(key)) {
+      return this.countMap.get(key).get();
+    }
+    return 0;
+  }
+  
+  /**
+   * Adds the key counts from the given other KeyCounter
+   * into this KeyCounter. 
+   * @param other
+   */
+  public synchronized void addOther(KeyCounter other) {
+    synchronized (other) {
+      for (Entry<String, AtomicInteger> entry : other.countMap.entrySet()) {
+        this.increment(entry.getKey(), entry.getValue().intValue());
+      }      
+    }
+  }
+}

--- a/src/main/java/com/netflix/playback/features/model/KeyCounter.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyCounter.java
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @author tom
  *
  */
-public class KeyCounter {
+public final class KeyCounter {
 
   private final Map<String, AtomicInteger> countMap = Collections.synchronizedMap(
       new HashMap<String, AtomicInteger>());

--- a/src/main/java/com/netflix/playback/features/model/KeyLogger.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLogger.java
@@ -19,8 +19,7 @@ import com.netflix.common.SynchronizedEventBus;
  * @author tom
  *
  */
-// TODO: Split this into an ABC and synchronous subclass
-public class KeyLogger {
+public final class KeyLogger {
   /**
    * Private Event class used to wrap a logged set of 
    * string keys in such away that they can be published

--- a/src/main/java/com/netflix/playback/features/model/KeyLogger.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLogger.java
@@ -19,21 +19,6 @@ import com.netflix.common.SynchronizedEventBus;
 // TODO: Split this into an ABC and synchronous subclass
 public class KeyLogger {
   /**
-   * Handler interface for KeyLogger handlers. Any class wishing
-   * to register as a handler of KeyLogger keys must implement
-   * this interface.
-   * @author tom
-   *
-   */
-  public interface Handler {
-    /**
-     * Handles an array of string keys.
-     * @param key array of strings
-     */
-    public void handle(String... keys);
-  }
-  
-  /**
    * Private Event class used to wrap a logged set of 
    * string keys in such away that they can be published
    * to subscribers via the {@link SynchronizedEventBus}. 
@@ -60,13 +45,13 @@ public class KeyLogger {
    *
    */
   private class Subscriber implements EventSubscriber<KeyLogger.Event> {
-    private final Handler handler;
+    private final KeyLoggerHandler handler;
     
     /**
      * Instantiates the subscriber.
      * @param handler the handler to be wrapped.
      */
-    private Subscriber(Handler handler) {
+    private Subscriber(KeyLoggerHandler handler) {
       this.handler = handler;
     }
     
@@ -82,7 +67,7 @@ public class KeyLogger {
    * Registers the given handler to receive all subsequent logged keys.
    * @param handler the handler
    */
-  public void addHandler(Handler handler) {
+  public void addHandler(KeyLoggerHandler handler) {
     this.eventBus.addSubscriber(new KeyLogger.Subscriber(handler));
   }
   

--- a/src/main/java/com/netflix/playback/features/model/KeyLogger.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLogger.java
@@ -1,5 +1,6 @@
 package com.netflix.playback.features.model;
 
+import com.netflix.common.EventSubscriber;
 import com.netflix.common.SynchronizedEventBus;
 
 /**
@@ -15,6 +16,7 @@ import com.netflix.common.SynchronizedEventBus;
  * @author tom
  *
  */
+// TODO: Split this into an ABC and synchronous subclass
 public class KeyLogger {
   /**
    * Handler interface for KeyLogger handlers. Any class wishing
@@ -51,20 +53,20 @@ public class KeyLogger {
   }
   
   /**
-   * A subclass of {@link SynchronizedEventBus.EventSubscriber} which 
+   * A subclass of {@link EventSubscriber} which 
    * simply translates {@link SynchronizedEventBus} callbacks in to 
    * handler calls.
    * @author tom
    *
    */
-  private class EventSubscriber implements SynchronizedEventBus.EventSubscriber<KeyLogger.Event> {
+  private class Subscriber implements EventSubscriber<KeyLogger.Event> {
     private final Handler handler;
     
     /**
      * Instantiates the subscriber.
      * @param handler the handler to be wrapped.
      */
-    private EventSubscriber(Handler handler) {
+    private Subscriber(Handler handler) {
       this.handler = handler;
     }
     
@@ -81,7 +83,7 @@ public class KeyLogger {
    * @param handler the handler
    */
   public void addHandler(Handler handler) {
-    this.eventBus.addSubscriber(new KeyLogger.EventSubscriber(handler));
+    this.eventBus.addSubscriber(new KeyLogger.Subscriber(handler));
   }
   
   /**

--- a/src/main/java/com/netflix/playback/features/model/KeyLogger.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLogger.java
@@ -13,6 +13,9 @@ import com.netflix.common.SynchronizedEventBus;
  * The KeyLogger itself imposes no opinion on the semantics
  * of what keys represent to consumers, it in effect
  * simply acts as a dumb string router.
+ * 
+ * KeyLogger uses a SynchronizedEventBus under the hood so
+ * is thread safe.
  * @author tom
  *
  */

--- a/src/main/java/com/netflix/playback/features/model/KeyLogger.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLogger.java
@@ -1,0 +1,95 @@
+package com.netflix.playback.features.model;
+
+import com.netflix.common.SynchronizedEventBus;
+
+/**
+ * A KeyLogger is used to log occurrences of keys. 
+ * 
+ * Behaves much like a classic Logger, allowing multiple
+ * handlers to be registered, to which all logged keys
+ * are forwarded. 
+ * 
+ * The KeyLogger itself imposes no opinion on the semantics
+ * of what keys represent to consumers, it in effect
+ * simply acts as a dumb string router.
+ * @author tom
+ *
+ */
+public class KeyLogger {
+  /**
+   * Handler interface for KeyLogger handlers. Any class wishing
+   * to register as a handler of KeyLogger keys must implement
+   * this interface.
+   * @author tom
+   *
+   */
+  public interface Handler {
+    /**
+     * Handles an array of string keys.
+     * @param key array of strings
+     */
+    public void handle(String... keys);
+  }
+  
+  /**
+   * Private Event class used to wrap a logged set of 
+   * string keys in such away that they can be published
+   * to subscribers via the {@link SynchronizedEventBus}. 
+   * @author tom
+   *
+   */
+  private class Event {
+    private final String[] keys;
+    
+    private Event(String[] keys) {
+      this.keys = keys;
+    }
+    
+    private String[] getKeys() {
+      return this.keys;
+    }
+  }
+  
+  /**
+   * A subclass of {@link SynchronizedEventBus.EventSubscriber} which 
+   * simply translates {@link SynchronizedEventBus} callbacks in to 
+   * handler calls.
+   * @author tom
+   *
+   */
+  private class EventSubscriber implements SynchronizedEventBus.EventSubscriber<KeyLogger.Event> {
+    private final Handler handler;
+    
+    /**
+     * Instantiates the subscriber.
+     * @param handler the handler to be wrapped.
+     */
+    private EventSubscriber(Handler handler) {
+      this.handler = handler;
+    }
+    
+    @Override
+    public void onEvent(Event event) {
+      this.handler.handle(event.getKeys());
+    }
+  }
+  
+  private final SynchronizedEventBus<KeyLogger.Event> eventBus = new SynchronizedEventBus<KeyLogger.Event>();
+  
+  /**
+   * Registers the given handler to receive all subsequent logged keys.
+   * @param handler the handler
+   */
+  public void addHandler(Handler handler) {
+    this.eventBus.addSubscriber(new KeyLogger.EventSubscriber(handler));
+  }
+  
+  /**
+   * Logs one or more keys to the logger. All logged keys are forwarded to registered
+   * handlers.
+   * @param keys the keys
+   */
+  public void log(String... keys) {
+    this.eventBus.postEvent(new Event(keys));
+  }
+}

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
@@ -106,18 +106,4 @@ public final class KeyLoggerDiagnosticService extends DiagnosticService {
     }
     return allPeriodsCounter.getCount(key) / this.numCompletedPeriods;
   }
-
-  /**
-   * @return the key logger in use by this object.
-   */
-  public KeyLogger getKeyLogger() {
-    return this.keyLogger;
-  }
-  
-  /**
-   * @return the timer used by this object to signal period intervals.
-   */
-  public Timer getTimer() {
-    return this.timer;
-  }
 }

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
@@ -12,9 +12,10 @@ import java.util.Deque;
  */
 public final class KeyLoggerDiagnosticService extends DiagnosticService {
   
-  private KeyCounter allPeriodsCounter = new KeyCounter();
-  private Deque<KeyCounter> previousPeriodCounters = new ArrayDeque<KeyCounter>();
+  private final KeyCounter allPeriodsCounter = new KeyCounter();
+  private final Deque<KeyCounter> previousPeriodCounters = new ArrayDeque<KeyCounter>();
   private KeyCounter currentPeriodCounter = new KeyCounter();
+  private final KeyLogger keyLogger;
   
   /**
    * Instantiates the service, registering itself for timer callbacks
@@ -25,7 +26,7 @@ public final class KeyLoggerDiagnosticService extends DiagnosticService {
    */
   public KeyLoggerDiagnosticService(Timer timer, KeyLogger keyLogger) {
     super(timer, 0);
-    
+    this.keyLogger = keyLogger;
     keyLogger.addHandler(new KeyLogger.Handler() {
       
       @Override
@@ -104,5 +105,19 @@ public final class KeyLoggerDiagnosticService extends DiagnosticService {
       return 0;
     }
     return allPeriodsCounter.getCount(key) / this.numCompletedPeriods;
+  }
+
+  /**
+   * @return the key logger in use by this object.
+   */
+  public KeyLogger getKeyLogger() {
+    return this.keyLogger;
+  }
+  
+  /**
+   * @return the timer used by this object to signal period intervals.
+   */
+  public Timer getTimer() {
+    return this.timer;
   }
 }

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
@@ -1,0 +1,108 @@
+package com.netflix.playback.features.model;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * A subclass of {@link DiagnosticService} which listens to keys
+ * emitted from a provided {@link KeyLogger} and uses these keys
+ * to build and serve it's queryable diagnostic data set. 
+ * @author tom
+ *
+ */
+public final class KeyLoggerDiagnosticService extends DiagnosticService {
+  
+  private KeyCounter allPeriodsCounter = new KeyCounter();
+  private Deque<KeyCounter> previousPeriodCounters = new ArrayDeque<KeyCounter>();
+  private KeyCounter currentPeriodCounter = new KeyCounter();
+  
+  /**
+   * Instantiates the service, registering itself for timer callbacks
+   * at the pre-configured intervals and to receive all keys logged to
+   * the provided {@link KeyLogger}
+   * @param timer time
+   * @param keyLogger the key logger
+   */
+  public KeyLoggerDiagnosticService(Timer timer, KeyLogger keyLogger) {
+    super(timer, 0);
+    
+    keyLogger.addHandler(new KeyLogger.Handler() {
+      
+      @Override
+      public void handle(String... keys) {
+        KeyLoggerDiagnosticService.this.log(keys);
+      }
+    });
+    
+    this.timer.addCallback(new PeriodCompletedCallback() {
+      
+      @Override
+      public void doAction() {
+        KeyLoggerDiagnosticService.this.rotateCounters();
+      }
+    });
+  }
+  
+  /**
+   * "Rotates" the counters maintained by this service instance.
+   * 
+   * This action is taken in response to a timer period completion 
+   * callback indicating that we should stop counting keys for the 
+   * current period and start a new period.
+   * 
+   * In practice this means that:
+   * <ul>
+   * <li>the current counter should be added into the "all time counter"</li>
+   * <li>the current counter should be moved into the list of previous counters</li>
+   * <li>the oldest previous counter should be removed to ensure we retain at most 2 previous counters</li>
+   * </ul> 
+   * 
+   * Synchronized to ensure we don't attempt to log keys while this process is
+   * in progress.
+   */
+  private synchronized void rotateCounters() {
+    allPeriodsCounter.addOther(currentPeriodCounter);
+    previousPeriodCounters.add(currentPeriodCounter);
+    currentPeriodCounter = new KeyCounter();
+    if (previousPeriodCounters.size() > 2) {
+      previousPeriodCounters.pop();  
+    }
+    this.numCompletedPeriods++;
+  }
+  
+  /**
+   * Logs keys to the current counter. 
+   * @param keys the keys.
+   */
+  private synchronized void log(String... keys) {
+    for (String key : keys) {
+      this.currentPeriodCounter.increment(key);
+    }
+  }
+
+  @Override
+  public synchronized int count(String key) {
+    if (previousPeriodCounters.size() < 1) {
+      return 0;
+    }
+    return this.previousPeriodCounters.getLast().getCount(key);
+  }
+
+  @Override
+  public synchronized int rate(String key) {
+    if (previousPeriodCounters.size() < 2) {
+      return 0;
+    }
+    return (
+        previousPeriodCounters.getLast().getCount(key) - 
+        previousPeriodCounters.getFirst().getCount(key));
+  }
+
+  @Override
+  public synchronized int avg(String key) {
+    if (this.numCompletedPeriods < 1) {
+      return 0;
+    }
+    return allPeriodsCounter.getCount(key) / this.numCompletedPeriods;
+  }
+}

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
@@ -15,7 +15,6 @@ public final class KeyLoggerDiagnosticService extends DiagnosticService {
   private final KeyCounter allPeriodsCounter = new KeyCounter();
   private final Deque<KeyCounter> previousPeriodCounters = new ArrayDeque<KeyCounter>();
   private KeyCounter currentPeriodCounter = new KeyCounter();
-  private final KeyLogger keyLogger;
   
   /**
    * Instantiates the service, registering itself for timer callbacks
@@ -26,7 +25,6 @@ public final class KeyLoggerDiagnosticService extends DiagnosticService {
    */
   public KeyLoggerDiagnosticService(Timer timer, KeyLogger keyLogger) {
     super(timer, 0);
-    this.keyLogger = keyLogger;
     keyLogger.addHandler(new KeyLoggerHandler() {
       
       @Override

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
@@ -27,7 +27,7 @@ public final class KeyLoggerDiagnosticService extends DiagnosticService {
   public KeyLoggerDiagnosticService(Timer timer, KeyLogger keyLogger) {
     super(timer, 0);
     this.keyLogger = keyLogger;
-    keyLogger.addHandler(new KeyLogger.Handler() {
+    keyLogger.addHandler(new KeyLoggerHandler() {
       
       @Override
       public void handle(String... keys) {

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerDiagnosticService.java
@@ -24,7 +24,7 @@ public final class KeyLoggerDiagnosticService extends DiagnosticService {
    * @param keyLogger the key logger
    */
   public KeyLoggerDiagnosticService(Timer timer, KeyLogger keyLogger) {
-    super(timer, 0);
+    super(timer);
     keyLogger.addHandler(new KeyLoggerHandler() {
       
       @Override

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerHandler.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerHandler.java
@@ -1,0 +1,16 @@
+package com.netflix.playback.features.model;
+
+/**
+ * Handler interface for KeyLogger handlers. Any class wishing
+ * to register as a handler of KeyLogger keys must implement
+ * this interface.
+ * @author tom
+ *
+ */
+public interface KeyLoggerHandler {
+  /**
+   * Handles an array of string keys.
+   * @param key array of strings
+   */
+  public void handle(String... keys);
+}

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnostics.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnostics.java
@@ -1,0 +1,131 @@
+package com.netflix.playback.features.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Concrete {@link PlaybackDiagnostics} subclass which exposes
+ * various counts, rates and averages. 
+ *  
+ * @author tom
+ *
+ */
+public class KeyLoggerPlaybackDiagnostics extends PlaybackDiagnostics {
+  
+  private static final String REQUEST_KEY = "request";
+  private static final String UNIQUE_CUSTOMER_KEY = "uniqueCustomers";
+  private static final String UNIQUE_VIEWABLES_KEY = "uniqueViewables";
+  private static final String COUNTRY_KEY_FORMAT = "country:%s";
+  private static final String VIEWABLE_KEY_FORMAT = "viewableId:%d";
+  private static final String CUSTOMER_KEY_FORMAT = "customerId:%s";
+  
+  private final KeyLogger keyLogger;
+  private final Timer timer;
+  private final Set<String> uniqueCustomers = new HashSet<String>();
+  private final Set<Integer> uniqueViewables = new HashSet<Integer>();
+  
+  /**
+   * @param diagnosticService a diagnostic service instance
+   * @param timer the timer used to signal when each period ends
+   * @param keyLogger key logger to which new request data should be logged.
+   */
+  public KeyLoggerPlaybackDiagnostics(DiagnosticService diagnosticService, Timer timer, KeyLogger keyLogger) {
+    super(diagnosticService);
+    this.keyLogger = keyLogger;
+    this.timer = timer;
+    this.timer.addCallback(new PeriodCompletedCallback() {
+      
+      @Override
+      public void doAction() {
+        KeyLoggerPlaybackDiagnostics.this.resetSets();
+      }
+    });
+  }
+  
+  /**
+   * Clears the sets tracking the unique customer and viewables for the 
+   * current period. 
+   */
+  private synchronized void resetSets() {
+    this.uniqueCustomers.clear();
+    this.uniqueViewables.clear();
+  }
+  
+  /**
+   * Encodes the string key used to represent a request 
+   * associated with the given country.
+   * @param country the country
+   * @return the encoded key
+   */
+  private String encodeCountryKey(String country) {
+    return String.format(COUNTRY_KEY_FORMAT, country);
+  }
+  
+  /**
+   * Encodes the string key used to represent a request 
+   * associated with the given viewable.
+   * @param viewableId the id of the viewable
+   * @return the encoded key
+   */
+  private String encodeViewableKey(int viewableId) {
+    return String.format(VIEWABLE_KEY_FORMAT, viewableId);
+  }
+  
+  /**
+   * Encodes the string key used to represent a request 
+   * associated with the given customer.
+   * @param customerId the customer id
+   * @return the encoded key
+   */
+  private String encodeCustomerKey(String customerId) {
+    return String.format(CUSTOMER_KEY_FORMAT, customerId);
+  }
+  
+  @Override
+  public synchronized void log(PlaybackRequest request) {
+    // Break the request down into several attribute-based keys 
+    // which we'll log separately. This then allows us to 
+    // perform queries against those keys later.
+    this.keyLogger.log(
+        REQUEST_KEY,
+        encodeCountryKey(request.getCountry()),
+        encodeCustomerKey(request.getCustomerId()),
+        encodeViewableKey(request.getViewableId()));
+    
+    // If we determine that the customer or viewable have not
+    // been seen before in the current period, then log a
+    // key which indicates we've seen a new distinct 
+    // customer/viewable.
+    if (this.uniqueCustomers.add(request.getCustomerId())) {
+      this.keyLogger.log(UNIQUE_CUSTOMER_KEY);
+    }
+    if (this.uniqueViewables.add(request.getViewableId())) {
+      this.keyLogger.log(UNIQUE_VIEWABLES_KEY);
+    }      
+  }
+
+  @Override
+  public int requestCount() {
+    return this.diagnosticService.count(REQUEST_KEY);
+  }
+
+  @Override
+  public int avgRateRequestsPerCountry(String country) {
+    return this.diagnosticService.avg(encodeCountryKey(country));
+  }
+
+  @Override
+  public int requestCount(int viewableId) {
+    return this.diagnosticService.count(encodeViewableKey(viewableId));
+  }
+
+  @Override
+  public int uniqueCustomerCount() {
+    return this.diagnosticService.count(UNIQUE_CUSTOMER_KEY);
+  }
+
+  @Override
+  public int uniqueViewableCount() {
+    return this.diagnosticService.count(UNIQUE_VIEWABLES_KEY);
+  }
+}

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnostics.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnostics.java
@@ -12,7 +12,7 @@ import java.util.Set;
  * @author tom
  *
  */
-public class KeyLoggerPlaybackDiagnostics extends PlaybackDiagnostics {
+public final class KeyLoggerPlaybackDiagnostics extends PlaybackDiagnostics {
   
   private static final String REQUEST_KEY = "request";
   private static final String UNIQUE_CUSTOMER_KEY = "uniqueCustomers";

--- a/src/main/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnosticsFactory.java
+++ b/src/main/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnosticsFactory.java
@@ -1,0 +1,22 @@
+package com.netflix.playback.features.model;
+
+import java.util.concurrent.TimeUnit;
+
+public final class KeyLoggerPlaybackDiagnosticsFactory extends PlaybackDiagnosticsFactory {
+
+  private final KeyLogger keyLogger;
+  
+  public KeyLoggerPlaybackDiagnosticsFactory(KeyLogger keyLogger) {
+    super();
+    this.keyLogger = keyLogger;
+  }
+
+  @Override
+  public PlaybackDiagnostics create(TimeUnit timeUnit, long periodLength) {
+    Timer timer = new SimpleTimer(timeUnit, periodLength);
+    DiagnosticService diagnosticService = new KeyLoggerDiagnosticService(timer, this.keyLogger);
+    return new KeyLoggerPlaybackDiagnostics(diagnosticService, timer, this.keyLogger);
+  }
+  
+  
+}

--- a/src/main/java/com/netflix/playback/features/model/PlaybackDiagnosticsFactory.java
+++ b/src/main/java/com/netflix/playback/features/model/PlaybackDiagnosticsFactory.java
@@ -1,0 +1,9 @@
+package com.netflix.playback.features.model;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class PlaybackDiagnosticsFactory {
+
+  public abstract PlaybackDiagnostics create(TimeUnit timeUnit, long periodLength);
+  
+}

--- a/src/main/java/com/netflix/playback/features/model/SimpleTimer.java
+++ b/src/main/java/com/netflix/playback/features/model/SimpleTimer.java
@@ -3,6 +3,7 @@ package com.netflix.playback.features.model;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 
+import com.netflix.common.EventSubscriber;
 import com.netflix.common.SynchronizedEventBus;
 
 /**
@@ -17,12 +18,12 @@ public class SimpleTimer extends Timer {
   private class Event {}
   
   /**
-   * {@link SynchronizedEventBus.EventSubscriber} implementation which simply
+   * {@link EventSubscriber} implementation which simply
    * forwards the received event notification to the provided {@link PeriodCompletedCallback}. 
    * @author tom
    *
    */
-  private class EventSubscriber implements SynchronizedEventBus.EventSubscriber<SimpleTimer.Event> {
+  private class Subscriber implements EventSubscriber<SimpleTimer.Event> {
     private final PeriodCompletedCallback callback;
     
     /**
@@ -30,7 +31,7 @@ public class SimpleTimer extends Timer {
      * @param callback the {@link PeriodCompletedCallback} to be invoked in response to
      *        events being received by this subscriber.
      */
-    public EventSubscriber(PeriodCompletedCallback callback) {
+    public Subscriber(PeriodCompletedCallback callback) {
       this.callback = callback;
     }
     
@@ -67,7 +68,7 @@ public class SimpleTimer extends Timer {
 
   @Override
   public void addCallback(PeriodCompletedCallback callback) {
-    this.eventBus.addSubscriber(new SimpleTimer.EventSubscriber(callback));
+    this.eventBus.addSubscriber(new SimpleTimer.Subscriber(callback));
   }
 
   @Override

--- a/src/main/java/com/netflix/playback/features/model/SimpleTimer.java
+++ b/src/main/java/com/netflix/playback/features/model/SimpleTimer.java
@@ -13,7 +13,7 @@ import com.netflix.common.SynchronizedEventBus;
  * @author tom
  *
  */
-public class SimpleTimer extends Timer {
+public final class SimpleTimer extends Timer {
   
   private class Event {}
   

--- a/src/main/java/com/netflix/playback/features/model/SimpleTimer.java
+++ b/src/main/java/com/netflix/playback/features/model/SimpleTimer.java
@@ -1,0 +1,87 @@
+package com.netflix.playback.features.model;
+
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+
+import com.netflix.common.SynchronizedEventBus;
+
+/**
+ * A simple {@link Timer} implementation which uses a fixed-rate
+ * {@link java.util.Timer} internally to signal at regular
+ * intervals as indicated by the provided constructor args.
+ * @author tom
+ *
+ */
+public class SimpleTimer extends Timer {
+  
+  private class Event {}
+  
+  /**
+   * {@link SynchronizedEventBus.EventSubscriber} implementation which simply
+   * forwards the received event notification to the provided {@link PeriodCompletedCallback}. 
+   * @author tom
+   *
+   */
+  private class EventSubscriber implements SynchronizedEventBus.EventSubscriber<SimpleTimer.Event> {
+    private final PeriodCompletedCallback callback;
+    
+    /**
+     * Creates a new instance of the subscriber.
+     * @param callback the {@link PeriodCompletedCallback} to be invoked in response to
+     *        events being received by this subscriber.
+     */
+    public EventSubscriber(PeriodCompletedCallback callback) {
+      this.callback = callback;
+    }
+    
+    @Override
+    public void onEvent(Event event) {
+      callback.doAction();
+    } 
+  }
+  
+  private final SynchronizedEventBus<SimpleTimer.Event> eventBus = new SynchronizedEventBus<SimpleTimer.Event>(); 
+  private final java.util.Timer timer = new java.util.Timer(true);
+  private boolean isRunning = false;
+  
+  public SimpleTimer(TimeUnit timeUnit, long periodLength) {
+    super(timeUnit, periodLength);
+  }
+
+  @Override
+  public synchronized void start() {
+    if (this.isRunning) {
+      throw new IllegalStateException("Cannot start an already-running timer");
+    }
+    
+    long periodInMilliseconds = this.timeUnit.toMillis(this.periodLength);
+    timer.scheduleAtFixedRate(new TimerTask() {
+      
+      @Override
+      public void run() {
+        SimpleTimer.this.eventBus.postEvent(new SimpleTimer.Event());
+      }
+    }, periodInMilliseconds, periodInMilliseconds);
+    this.isRunning = true;
+  }
+
+  @Override
+  public void addCallback(PeriodCompletedCallback callback) {
+    this.eventBus.addSubscriber(new SimpleTimer.EventSubscriber(callback));
+  }
+
+  @Override
+  public synchronized void stop() {
+    if (!this.isRunning) {
+      throw new IllegalStateException("Cannot stop a non-running timer");
+    }    
+
+    this.timer.cancel();
+    this.isRunning = false;
+  }
+  
+  @Override
+  public synchronized boolean isRunning() {
+    return this.isRunning;
+  }
+}

--- a/src/main/java/com/netflix/playback/features/model/Timer.java
+++ b/src/main/java/com/netflix/playback/features/model/Timer.java
@@ -16,12 +16,19 @@ public abstract class Timer {
      * Start the timer.
      */
     public abstract void start();
+    
     /**
      * @param callback to be executed after each period completed.
      */
     public abstract void addCallback(PeriodCompletedCallback callback);
+    
     /**
      * Stop the timer.
      */
     public abstract void stop();
+    
+    /**
+     * @return true if the timer is currently running
+     */
+    public abstract boolean isRunning();
 }

--- a/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
+++ b/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
@@ -1,0 +1,56 @@
+package com.netflix.common;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SynchronizedEventBusTest {
+
+  private class FakeEvent {}
+  
+  private class FakeSubscriber implements SynchronizedEventBus.EventSubscriber<FakeEvent> {
+    private int callCount = 0;
+    
+    @Override
+    public void onEvent(FakeEvent event) {
+      this.callCount++;
+    }
+  }
+  
+  private SynchronizedEventBus<FakeEvent> bus;
+  
+  @Before
+  public void setUp() throws Exception {
+    this.bus = new SynchronizedEventBus<SynchronizedEventBusTest.FakeEvent>();
+  }
+
+  @Test
+  public void testNoSubscribers() {
+    // Really just testing that this doesn't blow up
+    bus.postEvent(new FakeEvent());
+  }
+
+  @Test
+  public void testMultipleSubscribers() {
+    FakeSubscriber subA = new FakeSubscriber();
+    bus.addSubscriber(subA);
+    bus.postEvent(new FakeEvent());
+    FakeSubscriber subB = new FakeSubscriber();
+    bus.addSubscriber(subB);
+    bus.postEvent(new FakeEvent());
+    assertEquals(2, subA.callCount);
+    assertEquals(1, subB.callCount);
+  }
+  
+  public void testAddSubscriberMultipleTimes() {
+    FakeSubscriber subA = new FakeSubscriber();
+    bus.addSubscriber(subA);
+    bus.postEvent(new FakeEvent());    
+    bus.addSubscriber(subA);
+    bus.addSubscriber(subA);
+    bus.postEvent(new FakeEvent());    
+    assertEquals(2, subA.callCount);
+  }
+}

--- a/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
+++ b/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
@@ -44,6 +44,7 @@ public class SynchronizedEventBusTest {
     assertEquals(1, subB.callCount);
   }
   
+  @Test
   public void testAddSubscriberMultipleTimes() {
     FakeSubscriber subA = new FakeSubscriber();
     bus.addSubscriber(subA);

--- a/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
+++ b/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
@@ -1,16 +1,15 @@
 package com.netflix.common;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class SynchronizedEventBusTest {
 
-  private class FakeEvent {}
+  public class FakeEvent {}
   
-  private class FakeSubscriber implements EventSubscriber<FakeEvent> {
+  public class FakeSubscriber implements EventSubscriber<FakeEvent> {
     private int callCount = 0;
     
     @Override
@@ -53,5 +52,18 @@ public class SynchronizedEventBusTest {
     bus.addSubscriber(subA);
     bus.postEvent(new FakeEvent());    
     assertEquals(2, subA.callCount);
+  }
+  
+  @Test
+  public void testConcurrentModification() {
+    bus.addSubscriber(new FakeSubscriber());
+    bus.addSubscriber(new EventSubscriber<SynchronizedEventBusTest.FakeEvent>() {
+      
+      @Override
+      public void onEvent(FakeEvent event) {
+        bus.removeSubscriber(this);
+      }
+    });
+    bus.postEvent(new FakeEvent());
   }
 }

--- a/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
+++ b/src/test/java/com/netflix/common/SynchronizedEventBusTest.java
@@ -10,7 +10,7 @@ public class SynchronizedEventBusTest {
 
   private class FakeEvent {}
   
-  private class FakeSubscriber implements SynchronizedEventBus.EventSubscriber<FakeEvent> {
+  private class FakeSubscriber implements EventSubscriber<FakeEvent> {
     private int callCount = 0;
     
     @Override

--- a/src/test/java/com/netflix/playback/features/model/FakeKeyLoggerHandler.java
+++ b/src/test/java/com/netflix/playback/features/model/FakeKeyLoggerHandler.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class FakeKeyLoggerHandler implements KeyLogger.Handler {
+public class FakeKeyLoggerHandler implements KeyLoggerHandler {
   public final List<String> allKeys = new ArrayList<String>();
   
   @Override

--- a/src/test/java/com/netflix/playback/features/model/FakeKeyLoggerHandler.java
+++ b/src/test/java/com/netflix/playback/features/model/FakeKeyLoggerHandler.java
@@ -1,0 +1,14 @@
+package com.netflix.playback.features.model;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FakeKeyLoggerHandler implements KeyLogger.Handler {
+  public final List<String> allKeys = new ArrayList<String>();
+  
+  @Override
+  public void handle(String... keys) {
+    allKeys.addAll(Arrays.asList(keys));
+  }
+}

--- a/src/test/java/com/netflix/playback/features/model/FakeTimer.java
+++ b/src/test/java/com/netflix/playback/features/model/FakeTimer.java
@@ -1,0 +1,42 @@
+package com.netflix.playback.features.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class FakeTimer extends Timer {
+  List<PeriodCompletedCallback> callbacks = new ArrayList<PeriodCompletedCallback>();
+  
+  public FakeTimer() {
+    super(TimeUnit.DAYS, 1); // dummy values to keep super happy
+  }
+
+  @Override
+  public void start() {
+    // does nothing
+  }
+
+  @Override
+  public void addCallback(PeriodCompletedCallback callback) {
+    callbacks.add(callback);
+  }
+  
+  /**
+   * Simulates a timer interval expiring
+   */
+  public void periodComplete() {
+    for (PeriodCompletedCallback callback : callbacks) {
+      callback.doAction();
+    }
+  }
+
+  @Override
+  public void stop() {
+    // does nothing
+  }
+
+  @Override
+  public boolean isRunning() {
+    return false;
+  }
+}

--- a/src/test/java/com/netflix/playback/features/model/KeyCounterTest.java
+++ b/src/test/java/com/netflix/playback/features/model/KeyCounterTest.java
@@ -1,0 +1,77 @@
+package com.netflix.playback.features.model;
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.css.Counter;
+
+import com.netflix.playback.features.model.KeyCounter;
+
+public class KeyCounterTest {
+  
+  private KeyCounter counter;
+  
+  @Before
+  public void setUp() throws Exception {
+    this.counter = new KeyCounter();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public void testIncrementSingleKey() {
+    this.counter.increment("a");
+    this.counter.increment("a");
+    assertEquals(2, this.counter.getCount("a"));
+  }
+
+  @Test
+  public void testIncrementMultipleKeys() {
+    this.counter.increment("a");
+    this.counter.increment("b");
+    this.counter.increment("c");
+    this.counter.increment("b");
+    this.counter.increment("c");
+    this.counter.increment("c");
+    assertEquals(1, this.counter.getCount("a"));
+    assertEquals(2, this.counter.getCount("b"));
+    assertEquals(3, this.counter.getCount("c"));    
+  }
+
+  @Test
+  public void testIncrementSingleKeyByValue() {
+    this.counter.increment("a", 4);
+    this.counter.increment("a", 2);
+    assertEquals(6, this.counter.getCount("a"));
+  }
+
+  @Test
+  public void testIncrementMultipleKeysByValue() {
+    this.counter.increment("a", 2);
+    this.counter.increment("b", 3);
+    this.counter.increment("c", 4);
+    this.counter.increment("b", 5);
+    this.counter.increment("c", 6);
+    this.counter.increment("c", 7);
+    assertEquals(2, this.counter.getCount("a"));
+    assertEquals(8, this.counter.getCount("b"));
+    assertEquals(17, this.counter.getCount("c"));    
+  }
+
+  @Test
+  public void testAddOther() {
+    KeyCounter other = new KeyCounter();
+    other.increment("a", 2);
+    other.increment("b", 3);
+    this.counter.increment("b");
+    this.counter.increment("c", 5);
+    this.counter.addOther(other);
+    assertEquals(2, this.counter.getCount("a"));
+    assertEquals(4, this.counter.getCount("b"));
+    assertEquals(5, this.counter.getCount("c"));
+  }
+
+}

--- a/src/test/java/com/netflix/playback/features/model/KeyLoggerDiagnosticServiceTest.java
+++ b/src/test/java/com/netflix/playback/features/model/KeyLoggerDiagnosticServiceTest.java
@@ -1,0 +1,129 @@
+package com.netflix.playback.features.model;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KeyLoggerDiagnosticServiceTest {
+  
+  private class FakeTimer extends Timer {
+    List<PeriodCompletedCallback> callbacks = new ArrayList<PeriodCompletedCallback>();
+    
+    public FakeTimer() {
+      super(TimeUnit.DAYS, 1); // dummy values to keep super happy
+    }
+
+    @Override
+    public void start() {
+      // does nothing
+    }
+
+    @Override
+    public void addCallback(PeriodCompletedCallback callback) {
+      callbacks.add(callback);
+    }
+    
+    /**
+     * Simulates a timer interval expiring
+     */
+    public void periodComplete() {
+      for (PeriodCompletedCallback callback : callbacks) {
+        callback.doAction();
+      }
+    }
+
+    @Override
+    public void stop() {
+      // does nothing
+    }
+
+    @Override
+    public boolean isRunning() {
+      return false;
+    }
+  }
+  
+  private KeyLoggerDiagnosticService service;
+  private FakeTimer timer;
+  private KeyLogger logger;
+
+  
+  @Before
+  public void setUp() throws Exception {
+    this.logger = new KeyLogger();
+    this.timer = new FakeTimer();
+    this.service = new KeyLoggerDiagnosticService(this.timer, this.logger);
+  }
+
+  @Test
+  public void testNoKeys() {
+    assertEquals(0, this.service.count("a"));
+    assertEquals(0, this.service.rate("a"));
+    assertEquals(0, this.service.avg("a"));
+  }
+
+  @Test
+  public void testWithinFirstPeriod() {
+    this.logger.log("a", "b", "c");
+    assertEquals(0, this.service.count("a"));
+    assertEquals(0, this.service.rate("a"));
+    assertEquals(0, this.service.avg("a"));
+  }
+
+  @Test
+  public void testAfterFirstPeriod() {
+    this.logger.log("a");
+    this.logger.log("a", "b");
+    this.logger.log("a", "b", "c");
+    this.timer.periodComplete();  
+    assertEquals(3, this.service.count("a"));
+    assertEquals(2, this.service.count("b"));
+    assertEquals(1, this.service.count("c"));
+    assertEquals(0, this.service.rate("a"));
+    assertEquals(0, this.service.rate("b"));
+    assertEquals(0, this.service.rate("c"));
+    assertEquals(3, this.service.avg("a"));
+    assertEquals(2, this.service.avg("b"));
+    assertEquals(1, this.service.avg("c"));
+  }
+
+  @Test
+  public void testAfterSecondPeriod() {
+    this.logger.log("a");
+    this.logger.log("a", "b");
+    this.logger.log("a", "b", "c");
+    this.timer.periodComplete();  
+    this.logger.log("a", "a", "a", "a", "a");
+    this.logger.log("b", "b", "b", "b");
+    this.logger.log("c", "c", "c");
+    this.timer.periodComplete();  
+    assertEquals(5, this.service.count("a"));
+    assertEquals(4, this.service.count("b"));
+    assertEquals(3, this.service.count("c"));
+    assertEquals(2, this.service.rate("a"));
+    assertEquals(2, this.service.rate("b"));
+    assertEquals(2, this.service.rate("c"));
+    assertEquals(4, this.service.avg("a"));
+    assertEquals(3, this.service.avg("b"));
+    assertEquals(2, this.service.avg("c"));
+  }
+
+  @Test
+  public void testAfterThirdPeriod() {
+    this.logger.log("a");
+    this.timer.periodComplete();  
+    this.logger.log("a", "a", "a");
+    this.timer.periodComplete();  
+    this.logger.log("a", "a", "a", "a", "a");
+    this.timer.periodComplete();  
+    assertEquals(5, this.service.count("a"));
+    assertEquals(2, this.service.rate("a"));
+    assertEquals(3, this.service.avg("a"));
+  }
+}

--- a/src/test/java/com/netflix/playback/features/model/KeyLoggerDiagnosticServiceTest.java
+++ b/src/test/java/com/netflix/playback/features/model/KeyLoggerDiagnosticServiceTest.java
@@ -1,53 +1,11 @@
 package com.netflix.playback.features.model;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class KeyLoggerDiagnosticServiceTest {
-  
-  private class FakeTimer extends Timer {
-    List<PeriodCompletedCallback> callbacks = new ArrayList<PeriodCompletedCallback>();
-    
-    public FakeTimer() {
-      super(TimeUnit.DAYS, 1); // dummy values to keep super happy
-    }
-
-    @Override
-    public void start() {
-      // does nothing
-    }
-
-    @Override
-    public void addCallback(PeriodCompletedCallback callback) {
-      callbacks.add(callback);
-    }
-    
-    /**
-     * Simulates a timer interval expiring
-     */
-    public void periodComplete() {
-      for (PeriodCompletedCallback callback : callbacks) {
-        callback.doAction();
-      }
-    }
-
-    @Override
-    public void stop() {
-      // does nothing
-    }
-
-    @Override
-    public boolean isRunning() {
-      return false;
-    }
-  }
   
   private KeyLoggerDiagnosticService service;
   private FakeTimer timer;

--- a/src/test/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnosticsTest.java
+++ b/src/test/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnosticsTest.java
@@ -1,0 +1,127 @@
+package com.netflix.playback.features.model;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class KeyLoggerPlaybackDiagnosticsTest {
+
+  private class FakeDiagnosticService extends DiagnosticService {
+    private Map<String, Integer> counts = new HashMap<String, Integer>();
+    private Map<String, Integer> rates = new HashMap<String, Integer>();
+    private Map<String, Integer> avgs = new HashMap<String, Integer>();
+
+    public FakeDiagnosticService(Timer timer, int numCompletedPeriods) {
+      super(timer, numCompletedPeriods);
+    }
+    
+    @Override
+    public int avg(String key) {
+      return avgs.get(key);
+    }
+    
+    @Override
+    public int count(String key) {
+      return counts.get(key);
+    }
+    
+    @Override
+    public int rate(String key) {
+      return rates.get(key);
+    }
+  }
+  
+  private KeyLoggerPlaybackDiagnostics diagnostics;
+  private KeyLogger keyLogger;
+  private DiagnosticService diagnosticService;
+  private FakeTimer timer;
+  
+  @Before
+  public void setUp() throws Exception {
+    this.timer = new FakeTimer();
+    this.keyLogger = new KeyLogger();
+    this.diagnosticService = new KeyLoggerDiagnosticService(this.timer, this.keyLogger);
+    this.diagnostics = new KeyLoggerPlaybackDiagnostics(diagnosticService, timer, keyLogger);
+  }
+
+  @Test
+  public void testLogging() {
+    FakeKeyLoggerHandler handler = new FakeKeyLoggerHandler();
+    this.keyLogger.addHandler(handler);
+    
+    this.diagnostics.log(new PlaybackRequest("bob", 33, "UK"));
+    this.diagnostics.log(new PlaybackRequest("bob", 32, "UK"));
+    this.diagnostics.log(new PlaybackRequest("jim", 32, "USA"));
+    
+    String[] expected = new String[]{
+        "country:UK", "country:UK", "country:USA", "customerId:bob", "customerId:bob", 
+        "customerId:jim", "request", "request", "request", "uniqueCustomers", 
+        "uniqueCustomers", "uniqueViewables", "uniqueViewables", "viewableId:32", 
+        "viewableId:32", "viewableId:33"};
+    handler.allKeys.sort(null);
+    assertArrayEquals(expected, handler.allKeys.toArray());
+  }
+
+  @Test
+  public void testRequestCount(){
+    this.diagnostics.log(new PlaybackRequest("bob", 33, "UK"));
+    this.diagnostics.log(new PlaybackRequest("bob", 32, "UK"));
+    this.diagnostics.log(new PlaybackRequest("jim", 32, "USA"));
+    assertEquals(0, this.diagnostics.requestCount());
+    assertEquals(0, this.diagnostics.requestCount(32));
+    assertEquals(0, this.diagnostics.requestCount(30));
+    this.timer.periodComplete();
+    assertEquals(3, this.diagnostics.requestCount());
+    assertEquals(2, this.diagnostics.requestCount(32));
+    assertEquals(0, this.diagnostics.requestCount(30));
+  }
+  
+  @Test
+  public void testAvgRateRequestsPerCountry() {
+    this.diagnostics.log(new PlaybackRequest("bob", 33, "UK"));
+    this.diagnostics.log(new PlaybackRequest("bob", 32, "UK"));
+    this.diagnostics.log(new PlaybackRequest("jim", 32, "USA"));
+    assertEquals(0, this.diagnostics.avgRateRequestsPerCountry("UK"));
+    assertEquals(0, this.diagnostics.avgRateRequestsPerCountry("USA"));
+    assertEquals(0, this.diagnostics.avgRateRequestsPerCountry("FR"));
+    this.timer.periodComplete();
+    assertEquals(2, this.diagnostics.avgRateRequestsPerCountry("UK"));
+    assertEquals(1, this.diagnostics.avgRateRequestsPerCountry("USA"));
+    assertEquals(0, this.diagnostics.avgRateRequestsPerCountry("FR"));
+    this.diagnostics.log(new PlaybackRequest("bob", 33, "UK"));
+    this.diagnostics.log(new PlaybackRequest("bob", 32, "USA"));
+    this.diagnostics.log(new PlaybackRequest("jim", 32, "USA"));
+    this.diagnostics.log(new PlaybackRequest("bob", 33, "UK"));
+    this.diagnostics.log(new PlaybackRequest("bob", 32, "USA"));
+    this.diagnostics.log(new PlaybackRequest("jim", 32, "USA"));
+    this.timer.periodComplete();
+    assertEquals(2, this.diagnostics.avgRateRequestsPerCountry("UK"));
+    assertEquals(2, this.diagnostics.avgRateRequestsPerCountry("USA"));
+    assertEquals(0, this.diagnostics.avgRateRequestsPerCountry("FR"));    
+  }
+  
+  @Test 
+  public void testUniqueCustomers() {
+    this.diagnostics.log(new PlaybackRequest("bob", 33, "UK"));
+    this.diagnostics.log(new PlaybackRequest("bob", 32, "UK"));
+    this.diagnostics.log(new PlaybackRequest("jim", 32, "USA"));
+    assertEquals(0, this.diagnostics.uniqueCustomerCount());
+    this.timer.periodComplete();
+    assertEquals(2, this.diagnostics.uniqueCustomerCount());
+  }
+
+  @Test 
+  public void testUniqueViewables() {
+    this.diagnostics.log(new PlaybackRequest("bob", 33, "UK"));
+    this.diagnostics.log(new PlaybackRequest("bob", 32, "UK"));
+    this.diagnostics.log(new PlaybackRequest("jim", 32, "USA"));
+    assertEquals(0, this.diagnostics.uniqueViewableCount());
+    this.timer.periodComplete();
+    assertEquals(2, this.diagnostics.uniqueViewableCount());
+  }
+}

--- a/src/test/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnosticsTest.java
+++ b/src/test/java/com/netflix/playback/features/model/KeyLoggerPlaybackDiagnosticsTest.java
@@ -10,31 +10,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class KeyLoggerPlaybackDiagnosticsTest {
-
-  private class FakeDiagnosticService extends DiagnosticService {
-    private Map<String, Integer> counts = new HashMap<String, Integer>();
-    private Map<String, Integer> rates = new HashMap<String, Integer>();
-    private Map<String, Integer> avgs = new HashMap<String, Integer>();
-
-    public FakeDiagnosticService(Timer timer, int numCompletedPeriods) {
-      super(timer, numCompletedPeriods);
-    }
-    
-    @Override
-    public int avg(String key) {
-      return avgs.get(key);
-    }
-    
-    @Override
-    public int count(String key) {
-      return counts.get(key);
-    }
-    
-    @Override
-    public int rate(String key) {
-      return rates.get(key);
-    }
-  }
   
   private KeyLoggerPlaybackDiagnostics diagnostics;
   private KeyLogger keyLogger;

--- a/src/test/java/com/netflix/playback/features/model/KeyLoggerTest.java
+++ b/src/test/java/com/netflix/playback/features/model/KeyLoggerTest.java
@@ -1,0 +1,46 @@
+package com.netflix.playback.features.model;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class KeyLoggerTest {
+  private KeyLogger keyLogger = new KeyLogger();
+  
+  private class FakeHandler implements KeyLogger.Handler {
+    private final List<String> allKeys = new ArrayList<String>();
+    
+    @Override
+    public void handle(String... keys) {
+      allKeys.addAll(Arrays.asList(keys));
+    }
+  }
+  
+  @Before
+  public void setUp() throws Exception {
+    keyLogger = new KeyLogger();
+  }
+
+  @Test
+  public void testNoHandlers() {
+    keyLogger.log("a", "b", "c");
+  }
+
+  @Test
+  public void testMultpleHandlers() {
+    FakeHandler handlerA = new FakeHandler();
+    FakeHandler handlerB = new FakeHandler();
+    keyLogger.addHandler(handlerA);
+    keyLogger.addHandler(handlerB);
+    keyLogger.log("a", "b", "c");
+    keyLogger.log("a", "b", "c", "d");
+    String[] expected = new String[]{"a", "b", "c", "a", "b", "c", "d"};
+    assertArrayEquals(expected, handlerA.allKeys.toArray());
+    assertArrayEquals(expected, handlerB.allKeys.toArray());
+  }
+}

--- a/src/test/java/com/netflix/playback/features/model/KeyLoggerTest.java
+++ b/src/test/java/com/netflix/playback/features/model/KeyLoggerTest.java
@@ -2,24 +2,11 @@ package com.netflix.playback.features.model;
 
 import static org.junit.Assert.assertArrayEquals;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 
 public class KeyLoggerTest {
   private KeyLogger keyLogger = new KeyLogger();
-  
-  private class FakeHandler implements KeyLogger.Handler {
-    private final List<String> allKeys = new ArrayList<String>();
-    
-    @Override
-    public void handle(String... keys) {
-      allKeys.addAll(Arrays.asList(keys));
-    }
-  }
   
   @Before
   public void setUp() throws Exception {
@@ -33,8 +20,8 @@ public class KeyLoggerTest {
 
   @Test
   public void testMultpleHandlers() {
-    FakeHandler handlerA = new FakeHandler();
-    FakeHandler handlerB = new FakeHandler();
+    FakeKeyLoggerHandler handlerA = new FakeKeyLoggerHandler();
+    FakeKeyLoggerHandler handlerB = new FakeKeyLoggerHandler();
     keyLogger.addHandler(handlerA);
     keyLogger.addHandler(handlerB);
     keyLogger.log("a", "b", "c");

--- a/src/test/java/com/netflix/playback/features/model/SimpleTimerTest.java
+++ b/src/test/java/com/netflix/playback/features/model/SimpleTimerTest.java
@@ -1,0 +1,66 @@
+package com.netflix.playback.features.model;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SimpleTimerTest {
+
+  private class FakeCallback implements PeriodCompletedCallback {
+    private int callCount;
+
+    @Override
+    public void doAction() {
+      callCount++;
+    }
+  }
+  
+  private SimpleTimer timer;
+  
+  @Before
+  public void setUp() throws Exception {
+    this.timer = new SimpleTimer(TimeUnit.MILLISECONDS, 10);
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    if (this.timer.isRunning()) {
+      this.timer.stop();
+    }
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testStartWhenAlreadyStarted() {
+    this.timer.start();
+    this.timer.start();
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testStopWhenAlreadyStopped() {
+    this.timer.stop();
+  }
+  
+  @Test
+  public void testCallback() throws InterruptedException {
+    FakeCallback callbackA = new FakeCallback();
+    FakeCallback callbackB = new FakeCallback();
+    this.timer.addCallback(callbackA);
+    this.timer.addCallback(callbackB);
+    
+    this.timer.start();
+    Thread.sleep(15L); 
+    assertEquals(1, callbackA.callCount);
+    assertEquals(1, callbackB.callCount);
+    Thread.sleep(10L); 
+    assertEquals(2, callbackA.callCount);
+    assertEquals(2, callbackB.callCount);
+    this.timer.stop();
+    Thread.sleep(10L); 
+    assertEquals(2, callbackA.callCount);
+    assertEquals(2, callbackB.callCount);
+  }
+}

--- a/src/test/java/com/netflix/playback/features/model/SimpleTimerTest.java
+++ b/src/test/java/com/netflix/playback/features/model/SimpleTimerTest.java
@@ -23,7 +23,7 @@ public class SimpleTimerTest {
   
   @Before
   public void setUp() throws Exception {
-    this.timer = new SimpleTimer(TimeUnit.MILLISECONDS, 10);
+    this.timer = new SimpleTimer(TimeUnit.MILLISECONDS, 20);
   }
   
   @After
@@ -52,14 +52,14 @@ public class SimpleTimerTest {
     this.timer.addCallback(callbackB);
     
     this.timer.start();
-    Thread.sleep(15L); 
+    Thread.sleep(29L); 
     assertEquals(1, callbackA.callCount);
     assertEquals(1, callbackB.callCount);
-    Thread.sleep(10L); 
+    Thread.sleep(20L); 
     assertEquals(2, callbackA.callCount);
     assertEquals(2, callbackB.callCount);
     this.timer.stop();
-    Thread.sleep(10L); 
+    Thread.sleep(20L); 
     assertEquals(2, callbackA.callCount);
     assertEquals(2, callbackB.callCount);
   }


### PR DESCRIPTION
@jstnbckr I thought this was probably enough code for an initial implementation. Please let me know if this aligns with your expectations or if there is any particular area you'd like me to refactor, optimize or expand on.

Some notes:
- I made the assumption that the API declared in the abstract classes you provided was essentially fixed and that the implementation should not alter them. 
- The implementation is based around the concept of a `KeyLogger`. The idea here is that our `KeyLoggerDiagnosticService` listens on a provided `KeyLogger` to build the various counts from which it derives its exposed stats. The `KeyLoggerPlaybackDiagnostics` class in turn publishes details of its logged `PlaybackRequest`s as keys to the same `KeyLogger`. There are couple of benefits here:
  - We can log our keys to one `KeyLogger` which could potentially be listened on by multiple consumers of which `KeyLoggerDiagnosticService` is but one  (e.g. imagine a service which archives the data to separate archival service).
  - We abstract out the mechanism by which keys are propagated - `KeyLogger`'s implementation could potentially be made asynchronous or send keys over the network for example.
- Given there were a couple of use cases for a thread-safe pubsub/event bus implementation, I created a generic implementation in `com.netflix.common`.
- I made a modest effort to mitigate the prospect of contention owing to synchronization. I believe there is scope to do more of this, let me know if you think it's needed.
- I intentionally tried to keep classes fairly decoupled from each other to make them more testable and inherently composable. I introduced an abstract factory implementation to allow them to be constructed and assembled in the correct manner.  

I'd estimate I probably spent about 8 hours total putting this together.
